### PR TITLE
fix: [CARE-4677] tests failed due to unmocked AWS calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
 # Needed for DynamoDB Local, which is used for unit tests
-FROM openjdk:15-alpine3.11
+FROM amazoncorretto:20-alpine3.18
 
 # And our own stuff goes here
 WORKDIR /usr/app
 COPY . ./
 RUN apk add --update \
     yarn \
-    python \
-    python-dev \
-    py-pip \
     build-base \
     nodejs \
     npm

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,5 +1,7 @@
 dynamodb:
-  image: amazon/dynamodb-local
+  # We have to stay on v1 until the jest-dynamodb package supports v2:
+  # https://github.com/shelfio/jest-dynamodb/issues/212
+  image: amazon/dynamodb-local:1.22.0
 
 beyonce:
   build: .


### PR DESCRIPTION
https://headspace.atlassian.net/browse/CARE-4677

Tests were failing in CI due to not pinning the version of `amazon/dynamodb-local`.

Note that SonarCloud flagged this because of running the Dockerfile as root. Based on the risk assessment that SonarCloud provides, it is _not_ a vulnerability in our use case since we do not use this Dockerfile for running a service in prod; we use it only for running tests.

<img width="716" alt="image" src="https://github.com/HeadspaceMeditation/beyonce/assets/1993853/78ca6f95-5f13-4731-8ec5-1e7eb02d8605">
